### PR TITLE
check for gl muzzle on isISR

### DIFF
--- a/addons/isr/functions/fnc_isISR.sqf
+++ b/addons/isr/functions/fnc_isISR.sqf
@@ -20,7 +20,7 @@ private _turretConfig = [_currentVehicle, _turret] call CBA_fnc_getTurret;
 if ((isNumber (_turretConfig >> "optics")) && {(getNumber (_turretConfig >> "optics")) == 0}) exitWith {false};
 
 // FFV
-if (currentMuzzle ace_player == currentWeapon ace_player) exitWith {false};
+if (currentMuzzle ace_player == currentWeapon ace_player || currentMuzzle ace_player == (weaponState ace_player select 1)) exitWith {false};
 
 private _result = false;
 

--- a/addons/isr/functions/fnc_isISR.sqf
+++ b/addons/isr/functions/fnc_isISR.sqf
@@ -20,7 +20,7 @@ private _turretConfig = [_currentVehicle, _turret] call CBA_fnc_getTurret;
 if ((isNumber (_turretConfig >> "optics")) && {(getNumber (_turretConfig >> "optics")) == 0}) exitWith {false};
 
 // FFV
-if (currentMuzzle ace_player == currentWeapon ace_player || currentMuzzle ace_player == (weaponState ace_player select 1)) exitWith {false};
+if (currentMuzzle ace_player == (weaponState ace_player select 1)) exitWith {false};
 
 private _result = false;
 


### PR DESCRIPTION
there is probably less silly way to fix the GL in FFV giving you ISR

weaponstate will give you secondary muzzle name and we just check with that
```sqf
weaponState ace_player
["arifle_TRG21_GL_black_F","EGLM","Single","",0,-1,0]
```