### PR TITLE
ADD- Add civilian AR-2 

### DIFF
--- a/addons/compat_vanilla/CfgMagazines.hpp
+++ b/addons/compat_vanilla/CfgMagazines.hpp
@@ -27,6 +27,13 @@ class CfgMagazines {
         descriptionShort = "Contains an OPFOR AR-2 Darter";
         AVAR(drone) = "O_UAV_01_F";
     };
+    class AVAR(C_IDAP_UAV_01_CASE): AVAR(base_darter) {
+        scope = 2;
+        scopeCurator = 2;
+        displayName = "AR-2 (IDAP)";
+        descriptionShort = "Contains a IDAP AR-2 Darter";
+        AVAR(drone) = "C_IDAP_UAV_01_F";
+    };
 
     // Pelican
     class AVAR(base_pelican): AVAR(base) {

--- a/addons/compat_vanilla/CfgVehicles.hpp
+++ b/addons/compat_vanilla/CfgVehicles.hpp
@@ -61,6 +61,10 @@ class CfgVehicles {
         AVAR(case) = QAVAR(O_UAV_01_CASE);
         delete assembleInfo;
     };
+    class C_IDAP_UAV_01_F: UAV_01_base_F {
+        AVAR(case) = QAVAR(C_IDAP_UAV_01_CASE);
+        delete assembleInfo;
+    };
 
     // Falcon
     class UAV_03_base_F: Helicopter_Base_F {


### PR DESCRIPTION
Adds the IDAP/Civ AR-2 as a deployable, as the pelicans don't have a camera