### PR TITLE
ADD - Basic GX-Drone compat

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -8,7 +8,8 @@ workshop = [
     "3499977893", # ADT
     "450814997", # CBA
     "463939057", # ACE3
-    "1779063631" # Zeus Enhanced
+    "1779063631", # Zeus Enhanced
+    "3460981677"
 ]
 
 [hemtt.launch.cup]

--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -8,8 +8,7 @@ workshop = [
     "3499977893", # ADT
     "450814997", # CBA
     "463939057", # ACE3
-    "1779063631", # Zeus Enhanced
-    "3460981677"
+    "1779063631" # Zeus Enhanced
 ]
 
 [hemtt.launch.cup]
@@ -24,4 +23,10 @@ workshop = [
 extends = "default"
 workshop = [
     "2975055854" # Mk13 Secondary
+]
+
+[hemtt.launch.gxdrones]
+extends = "default"
+workshop = [
+    "3460981677" # GX drones
 ]

--- a/addons/compat_gxdrones/$PBOPREFIX$
+++ b/addons/compat_gxdrones/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\arc\addons\compat_gxdrones

--- a/addons/compat_gxdrones/CfgVehicles.hpp
+++ b/addons/compat_gxdrones/CfgVehicles.hpp
@@ -1,0 +1,58 @@
+class CfgVehicles {
+    class Helicopter_Base_F;
+    class GX_BLACKHORNET_UAV_BASE: Helicopter_Base_F {
+        AVAR(mode) = "LOS";
+        AVAR(power)[] = { 100, 200, 300, 400, 600, 800, 1200, 1800 };
+        AVAR(defaultPower) = 100;
+        AVAR(freq)[] = { 433, 915, 1200, 2400, 5800 };
+        AVAR(defaultFreq) = 1200;
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+    class GX_DRONE40_UAV_BASE: Helicopter_Base_F {
+        AVAR(mode) = "LOS";
+        AVAR(power)[] = { 100, 200, 300 };
+        AVAR(defaultPower) = 100;
+        AVAR(freq)[] = { 2400, 5800 };
+        AVAR(defaultFreq) = 2400;
+        AVAR(noBattery) = 1;
+    };
+    class GX_MQ8B_UAV_BASE: Helicopter_Base_F {
+        AVAR(mode) = "SAT";
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+    class Car_F;
+    class GX_HONEYBADGER_UGV_BASE: Car_F {
+        AVAR(mode) = "SAT";
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+    class StaticMortar;
+    class GX_HUNTER_SP_LAUNCHER_BASE: StaticMortar {
+        AVAR(mode) = "SAT";
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+    class Plane_Base_F;
+    class GX_HUNTER_SP_UAV_BASE: Plane_Base_F {
+        AVAR(mode) = "SAT";
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+    class GX_RQ11B_UAV_BASE: Plane_Base_F {
+        AVAR(mode) = "LOS";
+        AVAR(power)[] = { 100, 200, 300, 400, 600, 800, 1200, 1800 };
+        AVAR(defaultPower) = 100;
+        AVAR(freq)[] = { 433, 915, 1200, 2400, 5800 };
+        AVAR(defaultFreq) = 1200;
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+    class Tank_F;
+    class GX_THEMIS_UGV_BASE: Tank_F {
+        AVAR(mode) = "SAT";
+        AVAR(noBattery) = 1;
+        AVAR(isr) = QEFUNC(isr,vanilla);
+    };
+};

--- a/addons/compat_gxdrones/CfgVehicles.hpp
+++ b/addons/compat_gxdrones/CfgVehicles.hpp
@@ -22,21 +22,25 @@ class CfgVehicles {
         AVAR(noBattery) = 1;
         AVAR(isr) = QEFUNC(isr,vanilla);
     };
+
     class Car_F;
     class GX_HONEYBADGER_UGV_BASE: Car_F {
-        AVAR(mode) = "SAT";
+        AVAR(mode) = "LOS";
+        AVAR(power)[] = { 100, 200, 300, 400, 600, 800, 1200, 1800 };
+        AVAR(defaultPower) = 100;
+        AVAR(freq)[] = { 433, 915, 1200, 2400, 5800 };
+        AVAR(defaultFreq) = 1200;
         AVAR(noBattery) = 1;
         AVAR(isr) = QEFUNC(isr,vanilla);
     };
-    class StaticMortar;
-    class GX_HUNTER_SP_LAUNCHER_BASE: StaticMortar {
-        AVAR(mode) = "SAT";
-        AVAR(noBattery) = 1;
-        AVAR(isr) = QEFUNC(isr,vanilla);
-    };
+
     class Plane_Base_F;
     class GX_HUNTER_SP_UAV_BASE: Plane_Base_F {
-        AVAR(mode) = "SAT";
+        AVAR(mode) = "LOS";
+        AVAR(power)[] = { 100, 200, 300, 400, 600, 800, 1200, 1800 };
+        AVAR(defaultPower) = 100;
+        AVAR(freq)[] = { 433, 915, 1200, 2400, 5800 };
+        AVAR(defaultFreq) = 1200;
         AVAR(noBattery) = 1;
         AVAR(isr) = QEFUNC(isr,vanilla);
     };
@@ -49,9 +53,14 @@ class CfgVehicles {
         AVAR(noBattery) = 1;
         AVAR(isr) = QEFUNC(isr,vanilla);
     };
+
     class Tank_F;
     class GX_THEMIS_UGV_BASE: Tank_F {
-        AVAR(mode) = "SAT";
+        AVAR(mode) = "LOS";
+        AVAR(power)[] = { 5000, 10000, 15000, 20000, 30000, 40000, 50000 };
+        AVAR(defaultPower) = 5000;
+        AVAR(freq)[] = { 433, 915, 1200, 2400 };
+        AVAR(defaultFreq) = 1200;
         AVAR(noBattery) = 1;
         AVAR(isr) = QEFUNC(isr,vanilla);
     };

--- a/addons/compat_gxdrones/config.cpp
+++ b/addons/compat_gxdrones/config.cpp
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = QUOTE(COMPONENT);
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {
+            "arc_core",
+            "gx_drones_uav_blackhornet",
+            "gx_drones_uav_drone40",
+            "gx_drones_uav_hunter",
+            "gx_drones_uav_mq8b",
+            "gx_drones_uav_rq11b",
+            "gx_drones_ugv_honeybadger",
+            "gx_drones_ugv_themis",
+            "A3_Air_F_Exp_UAV_04",
+
+        };
+        skipWhenMissingDependencies = 1;
+        author = "Cplhardcore";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/compat_gxdrones/config.cpp
+++ b/addons/compat_gxdrones/config.cpp
@@ -15,8 +15,7 @@ class CfgPatches {
             "gx_drones_uav_rq11b",
             "gx_drones_ugv_honeybadger",
             "gx_drones_ugv_themis",
-            "A3_Air_F_Exp_UAV_04",
-
+            "A3_Air_F_Exp_UAV_04"
         };
         skipWhenMissingDependencies = 1;
         author = "Cplhardcore";

--- a/addons/compat_gxdrones/script_component.hpp
+++ b/addons/compat_gxdrones/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT compat_gxdrones
+
+#include "..\main\script_mod.hpp"
+#include "..\main\script_macros.hpp"


### PR DESCRIPTION
Adds compat to GX drones
Doesn't use ARC batteries, uses GX instead
Ground vics are SAT along with large air, the rest are as close as they can to vanilla counterparts